### PR TITLE
enables Vulkan Intel Ray Tracing on supported hardware

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -523,7 +523,7 @@ option(
 option(
   'intel-clc',
   type : 'feature',
-  value : 'disabled',
+  value : 'enabled',
   description : 'Build the intel-clc compiler (enables Vulkan Intel Ray Tracing on supported hardware).'
 )
 option(


### PR DESCRIPTION
This is a distribution created and maintained by Intel so makes sense to enable all Intel features.